### PR TITLE
Fix activation of right-click on touch devices

### DIFF
--- a/src/gui/Base/HTile.qml
+++ b/src/gui/Base/HTile.qml
@@ -110,7 +110,7 @@ HButton {
 
     TapHandler {
         acceptedButtons: Qt.RightButton
-        acceptedPointerTypes: PointerDevice.GenericPointer
+        acceptedPointerTypes: PointerDevice.GenericPointer | PointerDevice.Pen
         onTapped: {
             rightClicked()
             if (contextMenu) contextMenuLoader.active = true

--- a/src/gui/Base/HTile.qml
+++ b/src/gui/Base/HTile.qml
@@ -110,7 +110,16 @@ HButton {
 
     TapHandler {
         acceptedButtons: Qt.RightButton
+        acceptedPointerTypes: PointerDevice.GenericPointer
         onTapped: {
+            rightClicked()
+            if (contextMenu) contextMenuLoader.active = true
+        }
+    }
+
+    TapHandler {
+        acceptedPointerTypes: PointerDevice.Finger | PointerDevice.Pen
+        onLongPressed: {
             rightClicked()
             if (contextMenu) contextMenuLoader.active = true
         }

--- a/src/gui/Pages/Chat/Timeline/EventDelegate.qml
+++ b/src/gui/Pages/Chat/Timeline/EventDelegate.qml
@@ -106,7 +106,13 @@ HColumnLayout {
 
     TapHandler {
         acceptedButtons: Qt.RightButton
+        acceptedPointerTypes: PointerDevice.GenericPointer
         onTapped: openContextMenu()
+    }
+
+    TapHandler {
+        acceptedPointerTypes: PointerDevice.Finger | PointerDevice.Pen
+        onLongPressed: openContextMenu()
     }
 
     HMenu {

--- a/src/gui/Pages/Chat/Timeline/EventDelegate.qml
+++ b/src/gui/Pages/Chat/Timeline/EventDelegate.qml
@@ -106,7 +106,7 @@ HColumnLayout {
 
     TapHandler {
         acceptedButtons: Qt.RightButton
-        acceptedPointerTypes: PointerDevice.GenericPointer
+        acceptedPointerTypes: PointerDevice.GenericPointer | PointerDevice.Pen
         onTapped: openContextMenu()
     }
 


### PR DESCRIPTION
This fixes activation of right click on touch device, as you expected. I have added activation of context menu by long press. However, it opens the menu on the left top corner, not next to the press. I presume it reads coordinates of the point device and does it wrong on touchscreen.