### PR TITLE
Add limited local read/unread tracking

### DIFF
--- a/src/backend/models/items.py
+++ b/src/backend/models/items.py
@@ -82,6 +82,7 @@ class Room(ModelItem):
     last_event_date: datetime = ZeroDate
 
     mentions: int = 0
+    unreads: int = 0
 
     def __lt__(self, other: "Room") -> bool:
         """Sort by join state, then descending last event date, then name.

--- a/src/backend/nio_callbacks.py
+++ b/src/backend/nio_callbacks.py
@@ -36,7 +36,6 @@ class NioCallbacks:
 
     client: "MatrixClient" = field()
 
-
     def __post_init__(self) -> None:
         """Register our methods as callbacks."""
 
@@ -109,9 +108,11 @@ class NioCallbacks:
             room, ev, content=co, mentions=mention_list,
         )
 
-        if HTML_PROCESSOR.user_id_link_in_html(co, self.client.user_id):
-            rooms = self.client.models[self.client.user_id, "rooms"]
-            rooms[room.room_id].mentions += 1
+        if self.client.first_sync_done.is_set() and self.client.open_room != room.room_id:
+            room = self.client.models[self.client.user_id, "rooms"][room.room_id]
+            room.unreads += 1
+            if HTML_PROCESSOR.user_id_link_in_html(co, self.client.user_id):
+                room.mentions += 1
 
 
 

--- a/src/gui/MainPane/Room.qml
+++ b/src/gui/MainPane/Room.qml
@@ -44,23 +44,23 @@ HTileDelegate {
                     color: theme.mainPane.listView.room.name
                 }
 
-                // HLabel {
-                //     text: model.mentions
-                //     font.pixelSize: theme.fontSize.small
-                //     verticalAlignment: Qt.AlignVCenter
-                //     leftPadding: theme.spacing / 4
-                //     rightPadding: leftPadding
+                HLabel {
+                    text: model.unreads
+                    font.pixelSize: theme.fontSize.small
+                    verticalAlignment: Qt.AlignVCenter
+                    leftPadding: theme.spacing / 4
+                    rightPadding: leftPadding
 
-                //     scale: model.mentions === 0 ? 0 : 1
-                //     visible: scale > 0
+                    scale: model.unreads === 0 ? 0 : 1
+                    visible: scale > 0
 
-                //     background: Rectangle {
-                //         color: theme.colors.alertBackground
-                //         radius: theme.radius / 4
-                //     }
+                    background: Rectangle {
+                        color: model.mentions === 0 ? theme.colors.unreadBackground : theme.colors.alertBackground
+                        radius: theme.radius / 4
+                    }
 
-                //     Behavior on scale { HNumberAnimation {} }
-                // },
+                    Behavior on scale { HNumberAnimation {} }
+                }
 
                 HIcon {
                     svgName: "invite-received"

--- a/src/gui/PageLoader.qml
+++ b/src/gui/PageLoader.qml
@@ -61,6 +61,8 @@ HLoader {
     function showRoom(userId, roomId) {
         _show("Pages/Chat/Chat.qml", {userId, roomId})
 
+        py.callClientCoro(userId, "room_read", [roomId], () => {})
+
         window.uiState.page           = "Pages/Chat/Chat.qml"
         window.uiState.pageProperties = {userId, roomId}
         window.uiStateChanged()

--- a/src/themes/Glass.qpl
+++ b/src/themes/Glass.qpl
@@ -59,6 +59,9 @@ colors:
     color negativeBackground:
         hsluv(0, saturation * 1.5, intensity * 52, opacity)
 
+    color unreadBackground:
+        hsluv(188, saturation * 1.5, intensity * 52, 1)
+
     color alertBackground: negativeBackground
 
     color brightText:  hsluv(0, 0, intensity * 100)

--- a/src/themes/Midnight.qpl
+++ b/src/themes/Midnight.qpl
@@ -62,6 +62,9 @@ colors:
     color negativeBackground:
         hsluv(0, saturation * 1.5, intensity * 52, opacity)
 
+    color unreadBackground:
+        hsluv(188, saturation * 1.5, intensity * 52, 1)
+
     color alertBackground: negativeBackground
 
     color brightText:  hsluv(0, 0, intensity * 100)


### PR DESCRIPTION
This adds some simple tracking of unread messages, including activating the previously unused unread/mention badge in the room list

This doesn't do anything to reflect or update that read marker or read receipts, but it does locally track which rooms haven't been opened since last receiving a message.  During the first sync, no rooms are marked as unread, but any time that a new message is received after that, the room that the message was received in is marked as unread until the user opens the room.

I know it's kinda a bandaid fix, but not being able to tell which rooms had unread messages was driving me crazy