### PR TITLE
Fix asyncio event loop init in qml_bridge.py

### DIFF
--- a/src/backend/qml_bridge.py
+++ b/src/backend/qml_bridge.py
@@ -40,11 +40,15 @@ class QMLBridge:
     """
 
     def __init__(self) -> None:
+        try:
+            self._loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+        self._loop.set_exception_handler(self._loop_exception_handler)
+
         from .backend import Backend
         self.backend: Backend = Backend()
-
-        self._loop = asyncio.get_event_loop()
-        self._loop.set_exception_handler(self._loop_exception_handler)
 
         Thread(target=self._start_asyncio_loop).start()
 


### PR DESCRIPTION
Depending on Python version the file may be imported in a thread and
asyncio only implicitly creates an event loop in the main thread of the
process.  Backend does things which need asyncio so we must ensure an
event loop exists before it is imported.

Fixes #15