### PR TITLE
[flatpak] Switch to KDE 5.14 runtime, update dependencies

### DIFF
--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -3,7 +3,7 @@
 ## Building Flatpak
 
 To build the Flatpak package, you will need `flatpak`, `flatpak-builder`, and
-KDE 5.12 runtime with SDK. `flatpak-builder` is usually available from
+KDE 5.14 runtime with SDK. `flatpak-builder` is usually available from
 the same repository as `flatpak`.
 
 [Flatpak setup instructions](https://flatpak.org/setup/)
@@ -12,7 +12,7 @@ To install the runtimes (remove the `--user` flag and run as root if you
 prefer system-wide installation):
 
 ```
-flatpak install --user flathub org.kde.Platform//5.12 org.kde.Sdk//5.12
+flatpak install --user flathub org.kde.Platform//5.14 org.kde.Sdk//5.14
 ```
 
 If the download fails for some reason, run `flatpak repair` before retrying.

--- a/packaging/flatpak/generate-flatpak-script.sh
+++ b/packaging/flatpak/generate-flatpak-script.sh
@@ -6,7 +6,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 
 cd "$DIR"
 
-python3 -m venv flatpak-env
+python3.7 -m venv flatpak-env
 export PATH="$DIR/flatpak-env/bin:$PATH"
 
 if [ ! -f flatpak-pip-generator ]; then

--- a/packaging/flatpak/mirage.flatpak.base.yaml
+++ b/packaging/flatpak/mirage.flatpak.base.yaml
@@ -1,7 +1,7 @@
 id: io.github.mirukana.mirage
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: "5.12"
+runtime-version: "5.14"
 
 command: mirage
 finish-args:
@@ -89,6 +89,7 @@ modules:
   - name: python3-matrix-nio
     buildsystem: simple
     build-commands:
+      - rm pyproject.toml
       - pip3 install --prefix=${FLATPAK_DEST} .
     sources:
       - type: git

--- a/packaging/flatpak/mirage.flatpak.yaml
+++ b/packaging/flatpak/mirage.flatpak.yaml
@@ -1,7 +1,7 @@
 id: io.github.mirukana.mirage
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: '5.12'
+runtime-version: '5.14'
 command: mirage
 finish-args:
 - --share=ipc
@@ -89,6 +89,18 @@ modules:
   - type: file
     url: https://files.pythonhosted.org/packages/ae/e7/d9c3a176ca4b02024debf82342dab36efadfc5776f9c8db077e8f6e71821/pycparser-2.20-py2.py3-none-any.whl
     sha256: 7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705
+- name: python3-importlib-metadata
+  buildsystem: simple
+  build-commands:
+  - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
+    importlib-metadata==1.6.0
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/b2/34/bfcb43cc0ba81f527bc4f40ef41ba2ff4080e047acb0586b56b3d017ace4/zipp-3.1.0-py3-none-any.whl
+    sha256: aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b
+  - type: file
+    url: https://files.pythonhosted.org/packages/ad/e4/891bfcaf868ccabc619942f27940c77a8a4b45fd8367098955bb7e152fb1/importlib_metadata-1.6.0-py2.py3-none-any.whl
+    sha256: 2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f
 - name: python3-multidict
   buildsystem: simple
   build-commands:
@@ -135,17 +147,14 @@ modules:
     url: https://files.pythonhosted.org/packages/cb/19/57503b5de719ee45e83472f339f617b0c01ad75cba44aba1e4c97c2b0abd/idna-2.9.tar.gz
     sha256: 7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb
   - type: file
-    url: https://files.pythonhosted.org/packages/e7/dd/f1713bc6638cc3a6a23735eff6ee09393b44b96176d3296693ada272a80b/typing_extensions-3.7.4.1.tar.gz
-    sha256: 091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2
-  - type: file
     url: https://files.pythonhosted.org/packages/d6/67/6e2507586eb1cfa6d55540845b0cd05b4b77c414f6bca8b00b45483b976e/yarl-1.4.2.tar.gz
     sha256: 58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b
   - type: file
     url: https://files.pythonhosted.org/packages/a1/78/aae1545aba6e87e23ecab8d212b58bb70e72164b67eb090b81bb17ad38e3/async-timeout-3.0.1.tar.gz
     sha256: 0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f
   - type: file
-    url: https://files.pythonhosted.org/packages/61/b4/475114b3f1671da634f89239e61038f8742d9ac13aa34b32a05bf8022d22/multidict-4.7.5.tar.gz
-    sha256: aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e
+    url: https://files.pythonhosted.org/packages/65/d4/fabdcc5ee4451c8a8e177e27ddfd131a53a82ecc5a3b68468b7e9f8d70b4/multidict-4.7.6.tar.gz
+    sha256: fbb77a75e529021e7c4a8d4e823d88ef4d23674a202be4f5addffc72cbb91430
   - type: file
     url: https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz
     sha256: 84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae
@@ -159,38 +168,23 @@ modules:
     url: https://files.pythonhosted.org/packages/89/e3/afebe61c546d18fb1709a61bee788254b40e736cff7271c7de5de2dc4128/idna-2.9-py2.py3-none-any.whl
     sha256: a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa
   - type: file
-    url: https://files.pythonhosted.org/packages/e1/1e/5a4441be21b0726c4464f3f23c8b19628372f606755a9d2e46c187e65ec4/async_timeout-3.0.1-py3-none-any.whl
-    sha256: 4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3
-  - type: file
     url: https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
     sha256: fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-  - type: file
-    url: https://files.pythonhosted.org/packages/46/03/07c4894aae38b0de52b52586b24bf189bb83e4ddabfe2e2c8f2419eec6f4/idna-ssl-1.1.0.tar.gz
-    sha256: a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c
   - type: file
     url: https://files.pythonhosted.org/packages/a2/db/4313ab3be961f7a763066401fb77f7748373b6094076ae2bda2806988af6/attrs-19.3.0-py2.py3-none-any.whl
     sha256: 08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c
   - type: file
-    url: https://files.pythonhosted.org/packages/03/92/705fe8aca27678e01bbdd7738173b8e7df0088a2202c80352f664630d638/typing_extensions-3.7.4.1-py3-none-any.whl
-    sha256: cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575
+    url: https://files.pythonhosted.org/packages/e1/1e/5a4441be21b0726c4464f3f23c8b19628372f606755a9d2e46c187e65ec4/async_timeout-3.0.1-py3-none-any.whl
+    sha256: 4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3
 - name: python3-appdirs
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    appdirs==1.4.3
+    appdirs==1.4.4
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/56/eb/810e700ed1349edde4cbdc1b2a21e28cdf115f9faf263f6bbf8447c1abf3/appdirs-1.4.3-py2.py3-none-any.whl
-    sha256: d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e
-- name: python3-async-generator
-  buildsystem: simple
-  build-commands:
-  - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    async-generator==1.10
-  sources:
-  - type: file
-    url: https://files.pythonhosted.org/packages/71/52/39d20e03abd0ac9159c162ec24b93fbcaa111e8400308f2465432495ca2b/async_generator-1.10-py3-none-any.whl
-    sha256: 01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b
+    url: https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl
+    sha256: a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
 - name: python3-async-timeout
   buildsystem: simple
   build-commands:
@@ -204,11 +198,11 @@ modules:
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    atomicwrites==1.3.0
+    atomicwrites==1.4.0
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/52/90/6155aa926f43f2b2a22b01be7241be3bfd1ceaf7d0b3267213e8127d41f4/atomicwrites-1.3.0-py2.py3-none-any.whl
-    sha256: 03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4
+    url: https://files.pythonhosted.org/packages/2c/a0/da5f49008ec6e9a658dbf5d7310a4debd397bce0b4db03cf8a410066bb87/atomicwrites-1.4.0-py2.py3-none-any.whl
+    sha256: 6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197
 - name: python3-attrs
   buildsystem: simple
   build-commands:
@@ -222,14 +216,14 @@ modules:
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    beautifulsoup4==4.8.2
+    beautifulsoup4==4.9.1
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/05/cf/ea245e52f55823f19992447b008bcbb7f78efc5960d77f6c34b5b45b36dd/soupsieve-2.0-py2.py3-none-any.whl
-    sha256: fcd71e08c0aee99aca1b73f45478549ee7e7fc006d51b37bec9e9def7dc22b69
+    url: https://files.pythonhosted.org/packages/6f/8f/457f4a5390eeae1cc3aeab89deb7724c965be841ffca6cfca9197482e470/soupsieve-2.0.1-py3-none-any.whl
+    sha256: 1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55
   - type: file
-    url: https://files.pythonhosted.org/packages/cb/a1/c698cf319e9cfed6b17376281bd0efc6bfc8465698f54170ef60a485ab5d/beautifulsoup4-4.8.2-py3-none-any.whl
-    sha256: 9fbb4d6e48ecd30bcacc5b63b94088192dcda178513b2ae3c394229f8911b887
+    url: https://files.pythonhosted.org/packages/66/25/ff030e2437265616a1e9b25ccc864e0371a0bc3adb7c5a404fd661c6f4f6/beautifulsoup4-4.9.1-py3-none-any.whl
+    sha256: a6237df3c32ccfaee4fd201c8f5f9d9df619b93121d01353a64a73ce8c6ef9a8
 - name: python3-blist
   buildsystem: simple
   build-commands:
@@ -243,11 +237,11 @@ modules:
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    cachetools==4.0.0
+    cachetools==4.1.0
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/08/6a/abf83cb951617793fd49c98cb9456860f5df66ff89883c8660aa0672d425/cachetools-4.0.0-py3-none-any.whl
-    sha256: b304586d357c43221856be51d73387f93e2a961598a9b6b6670664746f3b6c6c
+    url: https://files.pythonhosted.org/packages/b3/59/524ffb454d05001e2be74c14745b485681c6ed5f2e625f71d135704c0909/cachetools-4.1.0-py3-none-any.whl
+    sha256: de5d88f87781602201cde465d3afe837546663b168e8b39df67411b0bf10cefc
 - name: python3-cairocffi
   buildsystem: simple
   build-commands:
@@ -285,8 +279,8 @@ modules:
     url: https://files.pythonhosted.org/packages/0b/10/8332e2a40334292e584c88f24ebf1635c1704f77be50af73cccc7babdbb7/tinycss2-1.0.2.tar.gz
     sha256: 6427d0e3faa0a5e0e8c9f6437e2de26148a7a197a8b0992789f23d9a802788cf
   - type: file
-    url: https://files.pythonhosted.org/packages/39/47/f28067b187dd664d205f75b07dcc6e0e95703e134008a14814827eebcaab/Pillow-7.0.0.tar.gz
-    sha256: 4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946
+    url: https://files.pythonhosted.org/packages/ce/ef/e793f6ffe245c960c42492d0bb50f8d14e2ba223f1922a5c3c81569cec44/Pillow-7.1.2.tar.gz
+    sha256: a0b49960110bc6ff5fead46013bcb8825d101026d466f3a4de3476defe0fb0dd
   - type: file
     url: https://files.pythonhosted.org/packages/a4/5f/f8aa58ca0cf01cbcee728abc9d88bfeb74e95e6cb4334cfd5bed5673ea77/defusedxml-0.6.0.tar.gz
     sha256: f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5
@@ -303,14 +297,14 @@ modules:
     url: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
     sha256: a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
   - type: file
+    url: https://files.pythonhosted.org/packages/06/74/9b387472866358ebc08732de3da6dc48e44b0aacd2ddaa5cb85ab7e986a2/defusedxml-0.6.0-py2.py3-none-any.whl
+    sha256: 6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93
+  - type: file
     url: https://files.pythonhosted.org/packages/f7/99/b3a2c6393563ccbe081ffcceb359ec27a6227792c5169604c1bd8128031a/cairocffi-1.1.0.tar.gz
     sha256: f1c0c5878f74ac9ccb5d48b2601fcc75390c881ce476e79f4cfedd288b1b05db
   - type: file
     url: https://files.pythonhosted.org/packages/72/bb/9ad85eacc5f273b08bd5203a1d587479a93f27df9056e4e5f63276f4fd0e/cssselect2-0.3.0-py3-none-any.whl
     sha256: 97d7d4234f846f9996d838964d38e13b45541c18143bc55cf00e4bc1281ace76
-  - type: file
-    url: https://files.pythonhosted.org/packages/06/74/9b387472866358ebc08732de3da6dc48e44b0aacd2ddaa5cb85ab7e986a2/defusedxml-0.6.0-py2.py3-none-any.whl
-    sha256: 6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93
   - type: file
     url: https://files.pythonhosted.org/packages/94/2c/4e501f9c351343c8ba10d70b5a7ca97cdab2690af043a6e52ada65b85b6b/tinycss2-1.0.2-py3-none-any.whl
     sha256: 9fdacc0e22d344ddd2ca053837c133900fe820ae1222f63b79617490a498507a
@@ -341,15 +335,6 @@ modules:
   - type: file
     url: https://files.pythonhosted.org/packages/72/bb/9ad85eacc5f273b08bd5203a1d587479a93f27df9056e4e5f63276f4fd0e/cssselect2-0.3.0-py3-none-any.whl
     sha256: 97d7d4234f846f9996d838964d38e13b45541c18143bc55cf00e4bc1281ace76
-- name: python3-dataclasses
-  buildsystem: simple
-  build-commands:
-  - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    dataclasses==0.6
-  sources:
-  - type: file
-    url: https://files.pythonhosted.org/packages/26/2f/1095cdc2868052dd1e64520f7c0d5c8c550ad297e944e641dbf1ffbb9a5d/dataclasses-0.6-py3-none-any.whl
-    sha256: 454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f
 - name: python3-defusedxml
   buildsystem: simple
   build-commands:
@@ -363,11 +348,11 @@ modules:
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    filetype==1.0.6
+    filetype==1.0.7
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/f1/ad/e1e0e85a2c2d02f634a9a400b4476f8187a634ee9d629df16f6432a6ed21/filetype-1.0.6-py2.py3-none-any.whl
-    sha256: fd6d0ec56820acccf8c9fb6c3ba7e04a302f6ff6c70bcc09daf4842ae9e2ac30
+    url: https://files.pythonhosted.org/packages/b4/6b/7bc015da1a576ac037582ae0c5acb675371de9e017e860931e97a428ee31/filetype-1.0.7-py2.py3-none-any.whl
+    sha256: 353369948bb1c09b8b3ea3d78390b5586e9399bff9aab894a1dff954e31a66f6
 - name: python3-future
   buildsystem: simple
   build-commands:
@@ -417,23 +402,23 @@ modules:
     html-sanitizer==1.9.0
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/15/53/3692c565aea19f7d9dd696fee3d0062782e9ad5bf9535267180511a15967/soupsieve-2.0.tar.gz
-    sha256: e914534802d7ffd233242b785229d5ba0766a7f487385e3f714446a07bf540ae
+    url: https://files.pythonhosted.org/packages/3e/db/5ba900920642414333bdc3cb397075381d63eafc7e75c2373bbc560a9fa1/soupsieve-2.0.1.tar.gz
+    sha256: a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232
   - type: file
-    url: https://files.pythonhosted.org/packages/52/ba/0e121661f529e7f456e903bf5c4d255b8051d8ce2b5e629c5212efe4c3f1/beautifulsoup4-4.8.2.tar.gz
-    sha256: 05fd825eb01c290877657a56df4c6e4c311b3965bda790c613a3d6fb01a5462a
+    url: https://files.pythonhosted.org/packages/c6/62/8a2bef01214eeaa5a4489eca7104e152968729512ee33cb5fbbc37a896b7/beautifulsoup4-4.9.1.tar.gz
+    sha256: 73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7
   - type: file
-    url: https://files.pythonhosted.org/packages/39/2b/0a66d5436f237aff76b91e68b4d8c041d145ad0a2cdeefe2c42f76ba2857/lxml-4.5.0.tar.gz
-    sha256: 8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60
+    url: https://files.pythonhosted.org/packages/03/a8/73d795778143be51d8b86750b371b3efcd7139987f71618ad9f4b8b65543/lxml-4.5.1.tar.gz
+    sha256: 27ee0faf8077c7c1a589573b1450743011117f1aa1a91d5ae776bbc5ca6070f2
   - type: file
     url: https://files.pythonhosted.org/packages/72/ff/88fbb7c46d359f7cbf1f8bc9f63379ed6b5e3940a9fda88f9cf5cedf24da/html-sanitizer-1.9.0.tar.gz
     sha256: ef86b10c653b288dff4c51c0cc9cf93025c4c6a519a6e40eb1aa152861101929
   - type: file
-    url: https://files.pythonhosted.org/packages/05/cf/ea245e52f55823f19992447b008bcbb7f78efc5960d77f6c34b5b45b36dd/soupsieve-2.0-py2.py3-none-any.whl
-    sha256: fcd71e08c0aee99aca1b73f45478549ee7e7fc006d51b37bec9e9def7dc22b69
+    url: https://files.pythonhosted.org/packages/6f/8f/457f4a5390eeae1cc3aeab89deb7724c965be841ffca6cfca9197482e470/soupsieve-2.0.1-py3-none-any.whl
+    sha256: 1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55
   - type: file
-    url: https://files.pythonhosted.org/packages/cb/a1/c698cf319e9cfed6b17376281bd0efc6bfc8465698f54170ef60a485ab5d/beautifulsoup4-4.8.2-py3-none-any.whl
-    sha256: 9fbb4d6e48ecd30bcacc5b63b94088192dcda178513b2ae3c394229f8911b887
+    url: https://files.pythonhosted.org/packages/66/25/ff030e2437265616a1e9b25ccc864e0371a0bc3adb7c5a404fd661c6f4f6/beautifulsoup4-4.9.1-py3-none-any.whl
+    sha256: a6237df3c32ccfaee4fd201c8f5f9d9df619b93121d01353a64a73ce8c6ef9a8
   - type: file
     url: https://files.pythonhosted.org/packages/0a/a5/ed03ad639853d467988582ddb879ebe386057fa6fcc6adb29752bd8f4cbf/html_sanitizer-1.9.0-py2.py3-none-any.whl
     sha256: 8a2a43c9f8737675bf04dad817803b3a42fab7a1f8987d27433db7b2f1d8b34d
@@ -455,30 +440,6 @@ modules:
   - type: file
     url: https://files.pythonhosted.org/packages/89/e3/afebe61c546d18fb1709a61bee788254b40e736cff7271c7de5de2dc4128/idna-2.9-py2.py3-none-any.whl
     sha256: a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa
-- name: python3-idna-ssl
-  buildsystem: simple
-  build-commands:
-  - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    idna-ssl==1.1.0
-  sources:
-  - type: file
-    url: https://files.pythonhosted.org/packages/89/e3/afebe61c546d18fb1709a61bee788254b40e736cff7271c7de5de2dc4128/idna-2.9-py2.py3-none-any.whl
-    sha256: a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa
-  - type: file
-    url: https://files.pythonhosted.org/packages/46/03/07c4894aae38b0de52b52586b24bf189bb83e4ddabfe2e2c8f2419eec6f4/idna-ssl-1.1.0.tar.gz
-    sha256: a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c
-- name: python3-importlib-metadata
-  buildsystem: simple
-  build-commands:
-  - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    importlib-metadata==1.5.0
-  sources:
-  - type: file
-    url: https://files.pythonhosted.org/packages/b2/34/bfcb43cc0ba81f527bc4f40ef41ba2ff4080e047acb0586b56b3d017ace4/zipp-3.1.0-py3-none-any.whl
-    sha256: aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b
-  - type: file
-    url: https://files.pythonhosted.org/packages/8b/03/a00d504808808912751e64ccf414be53c29cad620e3de2421135fcae3025/importlib_metadata-1.5.0-py2.py3-none-any.whl
-    sha256: b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b
 - name: python3-jsonschema
   buildsystem: simple
   build-commands:
@@ -489,17 +450,17 @@ modules:
     url: https://files.pythonhosted.org/packages/b2/34/bfcb43cc0ba81f527bc4f40ef41ba2ff4080e047acb0586b56b3d017ace4/zipp-3.1.0-py3-none-any.whl
     sha256: aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b
   - type: file
-    url: https://files.pythonhosted.org/packages/65/eb/1f97cb97bfc2390a276969c6fae16075da282f5058082d4cb10c6c5c1dba/six-1.14.0-py2.py3-none-any.whl
-    sha256: 8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
-  - type: file
-    url: https://files.pythonhosted.org/packages/8b/03/a00d504808808912751e64ccf414be53c29cad620e3de2421135fcae3025/importlib_metadata-1.5.0-py2.py3-none-any.whl
-    sha256: b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b
-  - type: file
     url: https://files.pythonhosted.org/packages/a2/db/4313ab3be961f7a763066401fb77f7748373b6094076ae2bda2806988af6/attrs-19.3.0-py2.py3-none-any.whl
     sha256: 08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c
   - type: file
     url: https://files.pythonhosted.org/packages/9f/0d/cbca4d0bbc5671822a59f270e4ce3f2195f8a899c97d0d5abb81b191efb5/pyrsistent-0.16.0.tar.gz
     sha256: 28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3
+  - type: file
+    url: https://files.pythonhosted.org/packages/ad/e4/891bfcaf868ccabc619942f27940c77a8a4b45fd8367098955bb7e152fb1/importlib_metadata-1.6.0-py2.py3-none-any.whl
+    sha256: 2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f
+  - type: file
+    url: https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl
+    sha256: 8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
   - type: file
     url: https://files.pythonhosted.org/packages/c5/8f/51e89ce52a085483359217bc72cdbf6e75ee595d5b1d4b5ade40c7e018b8/jsonschema-3.2.0-py2.py3-none-any.whl
     sha256: 4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163
@@ -516,11 +477,11 @@ modules:
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    lxml==4.5.0
+    lxml==4.5.1
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/39/2b/0a66d5436f237aff76b91e68b4d8c041d145ad0a2cdeefe2c42f76ba2857/lxml-4.5.0.tar.gz
-    sha256: 8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60
+    url: https://files.pythonhosted.org/packages/03/a8/73d795778143be51d8b86750b371b3efcd7139987f71618ad9f4b8b65543/lxml-4.5.1.tar.gz
+    sha256: 27ee0faf8077c7c1a589573b1450743011117f1aa1a91d5ae776bbc5ca6070f2
 - name: python3-mistune
   buildsystem: simple
   build-commands:
@@ -534,20 +495,20 @@ modules:
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    peewee==3.13.1
+    peewee==3.13.3
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/d4/30/0083f0e484902d118927236497c5f55c14a46c2a0e1b95083d26e5608371/peewee-3.13.1.tar.gz
-    sha256: 9492af4d1f8e18a7fa0e930960315b38931286ea0f1659bbd5503456cffdacde
+    url: https://files.pythonhosted.org/packages/e1/3e/a21e7268fa39756cdbd6d86af78ff1c0a92b84d6dbfadff431e9e3b9e1d3/peewee-3.13.3.tar.gz
+    sha256: 1269a9736865512bd4056298003aab190957afe07d2616cf22eaf56cb6398369
 - name: python3-Pillow
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    Pillow==7.0.0
+    Pillow==7.1.2
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/39/47/f28067b187dd664d205f75b07dcc6e0e95703e134008a14814827eebcaab/Pillow-7.0.0.tar.gz
-    sha256: 4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946
+    url: https://files.pythonhosted.org/packages/ce/ef/e793f6ffe245c960c42492d0bb50f8d14e2ba223f1922a5c3c81569cec44/Pillow-7.1.2.tar.gz
+    sha256: a0b49960110bc6ff5fead46013bcb8825d101026d466f3a4de3476defe0fb0dd
 - name: python3-pycparser
   buildsystem: simple
   build-commands:
@@ -579,11 +540,11 @@ modules:
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    pymediainfo==4.1
+    pymediainfo==4.2.1
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/97/87/1a79ccbf656392b3053d667dbf903b183d55ecf13cb6439293a700a8de00/pymediainfo-4.1.tar.gz
-    sha256: ed6a8f3dcd255895021d40d1299be333a1bead3dbe8df4cbe1a863ba8fee1756
+    url: https://files.pythonhosted.org/packages/52/0a/26b306633acd86cf3b28ee8c08f13b8a033ccc94aeacda4d17fdc6d1cabf/pymediainfo-4.2.1.tar.gz
+    sha256: 392d99d6bf74046ebaa2f7036d92d5327611d27532a384540e9310a62b8be26d
 - name: python3-pyrsistent
   buildsystem: simple
   build-commands:
@@ -591,8 +552,8 @@ modules:
     pyrsistent==0.16.0
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/65/eb/1f97cb97bfc2390a276969c6fae16075da282f5058082d4cb10c6c5c1dba/six-1.14.0-py2.py3-none-any.whl
-    sha256: 8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
+    url: https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl
+    sha256: 8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
   - type: file
     url: https://files.pythonhosted.org/packages/9f/0d/cbca4d0bbc5671822a59f270e4ce3f2195f8a899c97d0d5abb81b191efb5/pyrsistent-0.16.0.tar.gz
     sha256: 28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3
@@ -621,11 +582,11 @@ modules:
   buildsystem: simple
   build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    soupsieve==2.0
+    soupsieve==2.0.1
   sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/05/cf/ea245e52f55823f19992447b008bcbb7f78efc5960d77f6c34b5b45b36dd/soupsieve-2.0-py2.py3-none-any.whl
-    sha256: fcd71e08c0aee99aca1b73f45478549ee7e7fc006d51b37bec9e9def7dc22b69
+    url: https://files.pythonhosted.org/packages/6f/8f/457f4a5390eeae1cc3aeab89deb7724c965be841ffca6cfca9197482e470/soupsieve-2.0.1-py3-none-any.whl
+    sha256: 1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55
 - name: python3-tinycss2
   buildsystem: simple
   build-commands:
@@ -638,15 +599,6 @@ modules:
   - type: file
     url: https://files.pythonhosted.org/packages/94/2c/4e501f9c351343c8ba10d70b5a7ca97cdab2690af043a6e52ada65b85b6b/tinycss2-1.0.2-py3-none-any.whl
     sha256: 9fdacc0e22d344ddd2ca053837c133900fe820ae1222f63b79617490a498507a
-- name: python3-typing-extensions
-  buildsystem: simple
-  build-commands:
-  - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    typing-extensions==3.7.4.1
-  sources:
-  - type: file
-    url: https://files.pythonhosted.org/packages/03/92/705fe8aca27678e01bbdd7738173b8e7df0088a2202c80352f664630d638/typing_extensions-3.7.4.1-py3-none-any.whl
-    sha256: cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575
 - name: python3-unpaddedbase64
   buildsystem: simple
   build-commands:
@@ -675,8 +627,8 @@ modules:
     url: https://files.pythonhosted.org/packages/cb/19/57503b5de719ee45e83472f339f617b0c01ad75cba44aba1e4c97c2b0abd/idna-2.9.tar.gz
     sha256: 7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb
   - type: file
-    url: https://files.pythonhosted.org/packages/61/b4/475114b3f1671da634f89239e61038f8742d9ac13aa34b32a05bf8022d22/multidict-4.7.5.tar.gz
-    sha256: aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e
+    url: https://files.pythonhosted.org/packages/65/d4/fabdcc5ee4451c8a8e177e27ddfd131a53a82ecc5a3b68468b7e9f8d70b4/multidict-4.7.6.tar.gz
+    sha256: fbb77a75e529021e7c4a8d4e823d88ef4d23674a202be4f5addffc72cbb91430
   - type: file
     url: https://files.pythonhosted.org/packages/d6/67/6e2507586eb1cfa6d55540845b0cd05b4b77c414f6bca8b00b45483b976e/yarl-1.4.2.tar.gz
     sha256: 58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b
@@ -707,6 +659,6 @@ modules:
   - type: dir
     path: ../..
     skip:
-      - build
-      - .git
-      - .flatpak-builder
+    - build
+    - .git
+    - .flatpak-builder


### PR DESCRIPTION
This PR bumps to Flatpak runtime to 5.14, ensures that dependencies are generated with the same python as in the platform, and updates dependencies to the latest version.