### PR TITLE
Do not replace existing session (#63)

### DIFF
--- a/src/backend/backend.py
+++ b/src/backend/backend.py
@@ -136,7 +136,7 @@ class Backend:
             raise
 
         # Check if the user is already present on mirage
-        if client.user_id in self.clients.keys():
+        if client.user_id in self.clients:
             await client.logout()
             return client.user_id
 

--- a/src/backend/backend.py
+++ b/src/backend/backend.py
@@ -135,6 +135,11 @@ class Backend:
             await client.close()
             raise
 
+        # Check if the user is already present on mirage
+        if client.user_id in self.clients.keys():
+            await client.logout()
+            return client.user_id
+
         if order is None and not self.models["accounts"]:
             order = 0
         elif order is None:


### PR DESCRIPTION
Fixes #63
Do not let the user log in twice to the same account on Mirage. Redirect to account settings instead.