### PR TITLE
Print Window.qml component creation errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,6 +181,20 @@ int main(int argc, char *argv[]) {
         &engine,
         qrcPath.exists() ? "qrc:/src/gui/Window.qml" : "src/gui/Window.qml"
     );
+
+    if (component.isError()) {
+        for (QQmlError e : component.errors()) {
+            qFatal(
+                "%s:%d:%d: %s",
+                e.url().toString().toStdString().c_str(),
+                e.line(),
+                e.column(),
+                e.description().toStdString().c_str()
+            );
+        }
+        app.exit(EXIT_FAILURE);
+    }
+
     component.create(objectContext);
 
     // Finally, execute the app. Return its system exit code when it exits.


### PR DESCRIPTION
Print Window.qml component creation errors, if any. This explains the errors behind "component is not ready", because we are creating Window.qml from C++ side.