### PR TITLE
Require double click to open homepage

### DIFF
--- a/src/gui/MainPane/TopBar.qml
+++ b/src/gui/MainPane/TopBar.qml
@@ -60,7 +60,7 @@ Rectangle {
             text: qsTr("%1 %2")
                   .arg(Qt.application.displayName).arg(Qt.application.version)
             label.color: theme.mainPane.topBar.nameVersionLabel
-            toolTip.text: qsTr("Open project repository")
+            toolTip.text: qsTr("Double click to open project repository")
 
             onDoubleClicked:
                 Qt.openUrlExternally("https://github.com/mirukana/mirage")

--- a/src/gui/MainPane/TopBar.qml
+++ b/src/gui/MainPane/TopBar.qml
@@ -62,7 +62,7 @@ Rectangle {
             label.color: theme.mainPane.topBar.nameVersionLabel
             toolTip.text: qsTr("Open project repository")
 
-            onClicked:
+            onDoubleClicked:
                 Qt.openUrlExternally("https://github.com/mirukana/mirage")
 
             Layout.fillWidth: true


### PR DESCRIPTION
To raise mirage's window in a stacking wm clicking on an area without text, especially in the topbar, is probably what most users do. In the case of the 2nd button in the topbar this currently accidentally opens a browser window and thus becomes a privacy issue. So for now require a double click to open mirage's homepage. Alternatively the size of this button should at least be closely restricted to the text "Mirage ${version number}". In the long term it might be preferable to put this link into some kind of "about" section instead of the "title" section.