### PR TITLE
Add keybinding for quit

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -267,13 +267,13 @@ class Keys:
     # Mirage must be connected to a terminal for this to work.
     python_debugger = ["Shift+F1"]
 
-    # Quit Mirage
-    # quit = ["Ctrl+Q"]
-
     # Start the Python backend debugger in remote access mode.
     # The remote-pdb Python package must be installed.
     # From any terminal, run `socat readline tcp:127.0.0.1:4444` to connect.
     python_remote_debugger = ["Alt+F1"]
+
+    # Quit Mirage
+    quit = []
 
     class Scrolling:
         # Pages and chat timeline scrolling

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -267,6 +267,9 @@ class Keys:
     # Mirage must be connected to a terminal for this to work.
     python_debugger = ["Shift+F1"]
 
+    # Quit Mirage
+    # quit = ["Ctrl+Q"]
+
     # Start the Python backend debugger in remote access mode.
     # The remote-pdb Python package must be installed.
     # From any terminal, run `socat readline tcp:127.0.0.1:4444` to connect.

--- a/src/gui/UI.qml
+++ b/src/gui/UI.qml
@@ -90,9 +90,7 @@ Item {
 
     HShortcut {
         sequences: window.settings.Keys.quit
-        onActivated: {
-            Qt.quit()
-        }
+        onActivated: Qt.quit()
     }
 
     HShortcut {

--- a/src/gui/UI.qml
+++ b/src/gui/UI.qml
@@ -89,6 +89,13 @@ Item {
     }
 
     HShortcut {
+        sequences: window.settings.Keys.quit
+        onActivated: {
+            Qt.quit()
+        }
+    }
+
+    HShortcut {
         sequences: window.settings.Keys.notifications_highlights_only
         onActivated:
             mainUI.notificationLevel =


### PR DESCRIPTION
I tried adding a keybinding for quitting, `Ctrl`+`Q`

It is disabled by default because this binding is already used for replying.

I don't think it would be right to repurpose the key users are already used to. We don't want them quitting by accident all the time.

Regardless, `Ctrl`+`Q` is the standard binding for quitting GUI programs and I imagine a lot of new users would want it, so it's good to have it as an option.

I did notice that if I press the quit binding while Mirage is still opening/loading, it sometimes freezes instead of quitting, and then it needs to be `sigkill`-ed. So I'm probably missing something here. I've never worked with qml before so not sure how to go about debugging this.
