### PR TITLE
Add keys for back and forward through history of visited rooms

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -253,6 +253,11 @@ class Keys:
     # Switch to the last opened page/chat, similar to Alt+Tab on most desktops.
     last_page = ["Ctrl+Tab"]
 
+    # Go throgh history of opened chats,
+    # similar to the "page back" and "page forward" keys in web browsers
+    visit_history_back = ["Ctrl+H"]
+    visit_history_forward = ["Ctrl+Y"]
+
     # Toggle muting all notifications in the running client,
     # except highlights (e.g. replies or keywords)
     notifications_highlights_only = ["Ctrl+Alt+H"]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -255,8 +255,8 @@ class Keys:
 
     # Go throgh history of opened chats,
     # similar to the "page back" and "page forward" keys in web browsers
-    visit_history_back = ["Ctrl+H"]
-    visit_history_forward = ["Ctrl+Shift+H"]
+    earlier_page = ["Ctrl+H"]
+    later_page = ["Ctrl+Shift+H"]
 
     # Toggle muting all notifications in the running client,
     # except highlights (e.g. replies or keywords)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -256,7 +256,7 @@ class Keys:
     # Go throgh history of opened chats,
     # similar to the "page back" and "page forward" keys in web browsers
     earlier_page = ["Ctrl+H"]
-    later_page = ["Ctrl+Shift+H"]
+    later_page   = ["Ctrl+Shift+H"]
 
     # Whether to wrap around when using earlier_page and later_page
     wrap_history: bool = True

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -256,7 +256,7 @@ class Keys:
     # Go throgh history of opened chats,
     # similar to the "page back" and "page forward" keys in web browsers
     visit_history_back = ["Ctrl+H"]
-    visit_history_forward = ["Ctrl+Y"]
+    visit_history_forward = ["Ctrl+Shift+H"]
 
     # Toggle muting all notifications in the running client,
     # except highlights (e.g. replies or keywords)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -17,6 +17,10 @@ class General:
     # right room pane is visible at a time.
     hide_side_panes_under: int = 450
 
+    # Whether to wrap around or do nothing when using the earlier_page or
+    # later_page keybinds and reaching the start or end of the history.
+    wrap_history: bool = True
+
     # How many seconds the cursor must hover on buttons and other elements
     # to show tooltips.
     tooltips_delay: float = 0.5
@@ -257,9 +261,6 @@ class Keys:
     # similar to the "page back" and "page forward" keys in web browsers
     earlier_page = ["Ctrl+H"]
     later_page   = ["Ctrl+Shift+H"]
-
-    # Whether to wrap around when using earlier_page and later_page
-    wrap_history: bool = True
 
     # Toggle muting all notifications in the running client,
     # except highlights (e.g. replies or keywords)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -260,7 +260,7 @@ class Keys:
     # Go throgh history of opened chats,
     # similar to the "page back" and "page forward" keys in web browsers
     earlier_page = ["Ctrl+H"]
-    later_page   = ["Ctrl+Shift+H"]
+    later_page   = ["Ctrl+L"]
 
     # Toggle muting all notifications in the running client,
     # except highlights (e.g. replies or keywords)
@@ -462,7 +462,7 @@ class Keys:
 
         # Clear all messages from the chat.
         # This does not remove anything for other users.
-        clear_all = ["Ctrl+L"]
+        clear_all = ["Ctrl+Shift+L"]
 
     class ImageViewer:
         # Close the image viewer. Escape can also be used.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -258,6 +258,9 @@ class Keys:
     earlier_page = ["Ctrl+H"]
     later_page = ["Ctrl+Shift+H"]
 
+    # Whether to wrap around when using earlier_page and later_page
+    wrap_history: bool = True
+
     # Toggle muting all notifications in the running client,
     # except highlights (e.g. replies or keywords)
     notifications_highlights_only = ["Ctrl+Alt+H"]

--- a/src/gui/PageLoader.qml
+++ b/src/gui/PageLoader.qml
@@ -71,7 +71,7 @@ HLoader {
         return true
     }
 
-    function moveThroughVisitHistory(relativeMovement=1) {
+    function moveThroughHistory(relativeMovement=1) {
 
         // not allowed to go beyond oldest entry in history
         if (historyPosition + relativeMovement >= history.length) return false
@@ -122,12 +122,12 @@ HLoader {
     }
 
     HShortcut {
-        sequences: window.settings.Keys.visit_history_back
-        onActivated: moveThroughVisitHistory(1)
+        sequences: window.settings.Keys.earlier_page
+        onActivated: moveThroughHistory(1)
     }
 
     HShortcut {
-        sequences: window.settings.Keys.visit_history_forward
-        onActivated: moveThroughVisitHistory(-1)
+        sequences: window.settings.Keys.later_page
+        onActivated: moveThroughHistory(-1)
     }
 }

--- a/src/gui/PageLoader.qml
+++ b/src/gui/PageLoader.qml
@@ -76,18 +76,16 @@ HLoader {
     }
 
     function moveThroughHistory(relativeMovement=1) {
-
         if (history.length === 0) return false
 
-        // going beyond oldest entry in history
+        // Going beyond oldest entry in history
         if (historyPosition + relativeMovement >= history.length) {
-            if (!window.settings.Keys.wrap_history) return false
+            if (! window.settings.Keys.wrap_history) return false
             relativeMovement -= history.length
-        }
 
-        // going beyond newest entry in history
-        else if (historyPosition + relativeMovement < 0){
-            if (!window.settings.Keys.wrap_history) return false
+        // Going beyond newest entry in history
+        } else if (historyPosition + relativeMovement < 0){
+            if (! window.settings.Keys.wrap_history) return false
             relativeMovement += history.length
         }
 

--- a/src/gui/PageLoader.qml
+++ b/src/gui/PageLoader.qml
@@ -61,13 +61,17 @@ HLoader {
         show("Pages/Chat/Chat.qml", {userRoomId: [userId, roomId]})
     }
 
+    function showNthFromHistory(n, alterHistory=true) {
+        const [componentUrl, properties] = history[n]
+        show(componentUrl, properties, alterHistory)
+        previousShown(componentUrl, properties)
+    }
+
     function showPrevious(timesBack=1) {
         timesBack = Math.min(timesBack, history.length - 1)
         if (timesBack < 1) return false
 
-        const [componentUrl, properties] = history[timesBack]
-        show(componentUrl, properties)
-        previousShown(componentUrl, properties)
+        showNthFromHistory(timesBack)
         return true
     }
 
@@ -89,9 +93,7 @@ HLoader {
 
         historyPosition += relativeMovement
 
-        const [componentUrl, properties] = history[historyPosition]
-        show(componentUrl, properties, false)
-        previousShown(componentUrl, properties)
+        showNthFromHistory(historyPosition, false)
         return true
     }
 

--- a/src/gui/PageLoader.qml
+++ b/src/gui/PageLoader.qml
@@ -80,12 +80,12 @@ HLoader {
 
         // Going beyond oldest entry in history
         if (historyPosition + relativeMovement >= history.length) {
-            if (! window.settings.Keys.wrap_history) return false
+            if (! window.settings.General.wrap_history) return false
             relativeMovement -= history.length
 
         // Going beyond newest entry in history
         } else if (historyPosition + relativeMovement < 0){
-            if (! window.settings.Keys.wrap_history) return false
+            if (! window.settings.General.wrap_history) return false
             relativeMovement += history.length
         }
 

--- a/src/gui/PageLoader.qml
+++ b/src/gui/PageLoader.qml
@@ -73,11 +73,19 @@ HLoader {
 
     function moveThroughHistory(relativeMovement=1) {
 
-        // not allowed to go beyond oldest entry in history
-        if (historyPosition + relativeMovement >= history.length) return false
+        if (history.length === 0) return false
 
-        // not allowed to go beyond newest entry in history
-        if (historyPosition + relativeMovement < 0) return false
+        // going beyond oldest entry in history
+        if (historyPosition + relativeMovement >= history.length) {
+            if (!window.settings.Keys.wrap_history) return false
+            relativeMovement -= history.length
+        }
+
+        // going beyond newest entry in history
+        else if (historyPosition + relativeMovement < 0){
+            if (!window.settings.Keys.wrap_history) return false
+            relativeMovement += history.length
+        }
 
         historyPosition += relativeMovement
 


### PR DESCRIPTION
Use case: when you are active in many rooms at the same time (3 rooms, 4 rooms, N rooms), the history of recently visited rooms contains exactly what you need to quickly switch to. These bindings for going back and forwards through the history list enable quick switching while maintaining list order.

Inspiration came from Element which has this functionality on Alt+left and Alt+right (perhaps accidentally, because it is a browser).

I picked the bindings `Ctrl+H` and `Ctrl+Y` because they are easily reachable, adjacent, and `H` is for "History".

This does not change the functionality of `last_page` or any other room switching. However, if one does that while not at the end of history, a portion of the history will be discarded. Analogy: in the browser, go a few pages back, then click a different link.