### PR TITLE
fix .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 
 [submodule "submodules/RadialBarDemo"]
 	path = submodules/RadialBarDemo
-	url = https://github.com/mirukan/RadialBarDemo/
+	url = https://github.com/mirukana/RadialBarDemo
 
 [submodule "submodules/hsluv-c"]
 	path = submodules/hsluv-c


### PR DESCRIPTION
This is a two-character fix in .gitmodules that solves build issues by renaming `mirukan` to `mirukana`