### PR TITLE
Add keys for direct room switching

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -376,6 +376,15 @@ class Keys:
             9  = [Keys.alt_or_cmd() + "+9"]
             10 = [Keys.alt_or_cmd() + "+0"]
 
+        class Direct:
+            # Switch to a specific room with a keybinding.
+            # Each property is a list of keybinds for some room ID.
+            # Optionally, the account can be specified
+            # by using a space separator (see example).
+            # Unlimited entries can be added.
+            "!uxYVyZEASzrDCXMnNO:matrix.org" = ["Ctrl+G,Ctrl+M"]
+            "@account:example.org !roomID:a.org" = []
+
     class Chat:
         # Keybinds specific to the current chat page.
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -377,14 +377,15 @@ class Keys:
             10 = [Keys.alt_or_cmd() + "+0"]
 
         class Direct:
-            # Switch to a specific room with a keybinding.
-            # Each property is a list of keybinds for some room ID.
+            # Switch to specific rooms with keybindings.
+            # An unlimited number of properties can be added, where each
+            # property maps a room to a list of keybind.
             # A room's ID can be copied by right clicking on it in the room list.
-            # Optionally, the account can be specified
-            # by using a space separator (see example).
-            # Unlimited entries can be added.
             "!roomID:example.org" = []
-            "@account:example.org !roomID:a.org" = []
+
+            # If you have multiple accounts in the same room, you can also set
+            # which account should be targeted as "<userId> <roomId>":
+            "@account:example.org !roomID:example.org" = []
 
     class Chat:
         # Keybinds specific to the current chat page.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -382,7 +382,7 @@ class Keys:
             # Optionally, the account can be specified
             # by using a space separator (see example).
             # Unlimited entries can be added.
-            "!uxYVyZEASzrDCXMnNO:matrix.org" = ["Ctrl+G,Ctrl+M"]
+            "!uxYVyZEASzrDCXMnNO:matrix.org" = []
             "@account:example.org !roomID:a.org" = []
 
     class Chat:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -379,6 +379,7 @@ class Keys:
         class Direct:
             # Switch to a specific room with a keybinding.
             # Each property is a list of keybinds for some room ID.
+            # A room's ID can be copied by right clicking on it in the room list.
             # Optionally, the account can be specified
             # by using a space separator (see example).
             # Unlimited entries can be added.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -382,7 +382,7 @@ class Keys:
             # Optionally, the account can be specified
             # by using a space separator (see example).
             # Unlimited entries can be added.
-            "!uxYVyZEASzrDCXMnNO:matrix.org" = []
+            "!roomID:example.org" = []
             "@account:example.org !roomID:a.org" = []
 
     class Chat:

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -73,21 +73,15 @@ HListView {
             keepListCentered = true
     }
 
-    function findFirstAccountWithRoomId(roomId) {
-        var currentAccount = ""
+    function indexOfRoomId(roomId) {
         for (let i = 0; i < model.count; i++) {
-            var item = model.get(i)
-            if (item.type === "Account") {
-                currentAccount = item.id
-            }
-            else if (item.type === "Room") {
-                if (item.id === roomId) {
-                    return currentAccount
-                }
+            const item = model.get(i)
+            if (item.type === "Room" && item.id === roomId) {
+                return i
             }
         }
-        // failed
-        return false
+        return -1
+
     }
 
     // Description can be either room id
@@ -97,14 +91,13 @@ HListView {
         const spaceIndex = description.indexOf(" ")
         if (spaceIndex < 0) {
             // Description is just room id
-            if (accountId === false) {
             const roomId = description
             const roomIndex = indexOfRoomId(roomId)
+            if (roomIndex < 0) {
                 console.warn("No account with such room id: "+roomId)
             }
             else {
-                pageLoader.showRoom(accountId, roomId)
-                startCorrectItemSearch()
+                showItemAtIndex(roomIndex)
             }
         }
         else {

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -73,17 +73,6 @@ HListView {
             keepListCentered = true
     }
 
-    function indexOfRoomId(roomId) {
-        for (let i = 0; i < model.count; i++) {
-            const item = model.get(i)
-            if (item.type === "Room" && item.id === roomId) {
-                return i
-            }
-        }
-        return -1
-
-    }
-
     // Description can be either room id
     // or space-separated account id and room id.
     // If only room id, the first account with this room is used.
@@ -92,8 +81,8 @@ HListView {
         if (spaceIndex < 0) {
             // Description is just room id
             const roomId = description
-            const roomIndex = indexOfRoomId(roomId)
-            if (roomIndex < 0) {
+            const roomIndex = model.findIndex(roomId)
+            if (roomIndex === null) {
                 console.warn("No account with such room id: "+roomId)
             }
             else {

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -73,32 +73,25 @@ HListView {
             keepListCentered = true
     }
 
-    // Description can be either room id
-    // or space-separated account id and room id.
-    // If only room id, the first account with this room is used.
-    function showRoomByDescription(description) {
-        const [roomId, accountId] = description.split(" ").reverse()
-        if (accountId === undefined) {
-            // Description is just room id
+    function showById(roomId, accountId=null) {
+        // If only a room ID is passed, first account with this room is used
+        if (accountId === null) {
             const roomIndex = model.findIndex(roomId)
-            if (roomIndex === null) {
-                console.warn("No account with such room id: "+roomId)
-            }
-            else {
-                showItemAtIndex(roomIndex)
-            }
+
+            roomIndex === null ?
+            console.warn("No account with such room ID:", roomId) :
+            showItemAtIndex(roomIndex)
+
+            return
         }
-        else {
-            // Description is account id and room id
-            // Validate account id
-            if (accountIndice[accountId] === undefined) {
-                console.warn("No such account: "+accountId)
-            }
-            else {
-                pageLoader.showRoom(accountId, roomId)
-                startCorrectItemSearch()
-            }
+
+        if (! (accountId in accountIndice)) {
+            console.warn("No such account:", accountId)
+            return
         }
+
+        pageLoader.showRoom(accountId, roomId)
+        startCorrectItemSearch()
     }
 
     function showAccountRoomAtIndex(index) {
@@ -317,7 +310,7 @@ HListView {
         delegate: Loader {
             sourceComponent: HShortcut {
                 sequences: window.settings.Keys.Rooms.Direct[modelData]
-                onActivated: showRoomByDescription(modelData)
+                onActivated: showById(...modelData.split(/\s+/).reverse())
             }
         }
     }

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -94,12 +94,12 @@ HListView {
     // or space-separated account id and room id.
     // If only room id, the first account with this room is used.
     function showRoomByDescription(description) {
-        var spaceIndex = description.indexOf(" ")
+        const spaceIndex = description.indexOf(" ")
         if (spaceIndex < 0) {
             // Description is just room id
-            var roomId = description
-            var accountId = findFirstAccountWithRoomId(roomId)
             if (accountId === false) {
+            const roomId = description
+            const roomIndex = indexOfRoomId(roomId)
                 console.warn("No account with such room id: "+roomId)
             }
             else {
@@ -109,8 +109,8 @@ HListView {
         }
         else {
             // Description is account id and room id
-            var accountId = description.substring(0, spaceIndex)
-            var roomId = description.substring(spaceIndex+1)
+            const accountId = description.substring(0, spaceIndex)
+            const roomId = description.substring(spaceIndex+1)
             // Validate account id
             if (accountIndice[accountId] === undefined) {
                 console.warn("No such account: "+accountId)

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -73,6 +73,55 @@ HListView {
             keepListCentered = true
     }
 
+    function findFirstAccountWithRoomId(roomId) {
+        var currentAccount = ""
+        for (let i = 0; i < model.count; i++) {
+            var item = model.get(i)
+            if (item.type === "Account") {
+                currentAccount = item.id
+            }
+            else if (item.type === "Room") {
+                if (item.id === roomId) {
+                    return currentAccount
+                }
+            }
+        }
+        // failed
+        return false
+    }
+
+    // Description can be either room id
+    // or space-separated account id and room id.
+    // If only room id, the first account with this room is used.
+    function showRoomByDescription(description) {
+        var spaceIndex = description.indexOf(" ")
+        if (spaceIndex < 0) {
+            // Description is just room id
+            var roomId = description
+            var accountId = findFirstAccountWithRoomId(roomId)
+            if (accountId === false) {
+                console.warn("No account with such room id: "+roomId)
+            }
+            else {
+                pageLoader.showRoom(accountId, roomId)
+                startCorrectItemSearch()
+            }
+        }
+        else {
+            // Description is account id and room id
+            var accountId = description.substring(0, spaceIndex)
+            var roomId = description.substring(spaceIndex+1)
+            // Validate account id
+            if (accountIndice[accountId] === undefined) {
+                console.warn("No such account: "+accountId)
+            }
+            else {
+                pageLoader.showRoom(accountId, roomId)
+                startCorrectItemSearch()
+            }
+        }
+    }
+
     function showAccountRoomAtIndex(index) {
         const item = model.get(currentIndex === -1 ?  0 : currentIndex)
 
@@ -281,6 +330,14 @@ HListView {
                 sequences: window.settings.Keys.Rooms.AtIndex[modelData]
                 onActivated: showAccountRoomAtIndex(parseInt(modelData, 10) - 1)
             }
+        }
+    }
+
+    Instantiator {
+        model: Object.keys(window.settings.Keys.Rooms.Direct)
+        delegate: HShortcut {
+            sequences: window.settings.Keys.Rooms.Direct[modelData]
+            onActivated: showRoomByDescription(modelData)
         }
     }
 

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -314,9 +314,11 @@ HListView {
 
     Instantiator {
         model: Object.keys(window.settings.Keys.Rooms.Direct)
-        delegate: HShortcut {
-            sequences: window.settings.Keys.Rooms.Direct[modelData]
-            onActivated: showRoomByDescription(modelData)
+        delegate: Loader {
+            sourceComponent: HShortcut {
+                sequences: window.settings.Keys.Rooms.Direct[modelData]
+                onActivated: showRoomByDescription(modelData)
+            }
         }
     }
 

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -77,10 +77,9 @@ HListView {
     // or space-separated account id and room id.
     // If only room id, the first account with this room is used.
     function showRoomByDescription(description) {
-        const spaceIndex = description.indexOf(" ")
-        if (spaceIndex < 0) {
+        const [roomId, accountId] = description.split(" ").reverse()
+        if (accountId === undefined) {
             // Description is just room id
-            const roomId = description
             const roomIndex = model.findIndex(roomId)
             if (roomIndex === null) {
                 console.warn("No account with such room id: "+roomId)
@@ -91,8 +90,6 @@ HListView {
         }
         else {
             // Description is account id and room id
-            const accountId = description.substring(0, spaceIndex)
-            const roomId = description.substring(spaceIndex+1)
             // Validate account id
             if (accountIndice[accountId] === undefined) {
                 console.warn("No such account: "+accountId)


### PR DESCRIPTION
The one thing better than history navigation keys are keys for jumping directly to your favorite rooms, bindings that always work regardless of context.

This is a draft, ideally we want to offer more than a fixed number of slots. Personally I use 16 slots on a big account, bound to 2- or 3-key chords.

I wasn't able to figure out how to make one `HShortcut` do all this, so I currently have one for each and they're all just copy pasted.