### PR TITLE
Key to jump to latest/oldest unread

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -357,12 +357,21 @@ class Keys:
         previous_unread = ["Alt+Shift+U"]
         next_unread     = ["Alt+U"]
 
+        # Switch to the room with the oldest/latest unread message.
+        oldest_unread = ["Ctrl+Shift+U"]
+        latest_unread = ["Ctrl+U"]
+
         # Switch to the previous/next room with highlighted messages in the
         # list. What causes a highlight is controlled by push rules
         # (editable in GUI account settings): by default, this includes
         # when your name is mentioned, replied to, or messages with keywords.
         previous_highlight = ["Alt+Shift+M"]
         next_highlight     = ["Alt+M"]
+
+        # Switch to the room with the oldest/latest unread message,
+        # but only rooms with highlights are considered.
+        oldest_highlight = ["Ctrl+Shift+M"]
+        latest_highlight = ["Ctrl+M"]
 
         class AtIndex:
             # Switch to room number X in the current account.

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -104,10 +104,10 @@ HListView {
     }
 
     function cycleUnreadRooms(forward=true, highlights=false) {
-        const prop       = highlights ? "highlights" : "unreads"
-        const local_prop = highlights ? "highlights" : "local_unreads"
-        const start      = currentIndex === -1 ? 0 : currentIndex
-        let index        = start
+        const prop      = highlights ? "highlights": "unreads"
+        const localProp = highlights ? "highlights":  "local_unreads"
+        const start     = currentIndex === -1 ? 0:   currentIndex
+        let index       = start
 
         while (true) {
             index += forward ? 1 : -1
@@ -122,7 +122,7 @@ HListView {
 
             const item = model.get(index)
 
-            if (item.type === "Room" && (item[prop] || item[local_prop])) {
+            if (item.type === "Room" && (item[prop] || item[localProp])) {
                 currentIndex = index
                 return true
             }
@@ -131,23 +131,25 @@ HListView {
 
     // Find latest highlight or unread. If oldest=true, find oldest instead.
     function latestUnreadRoom(oldest=false, highlights=false) {
-        const prop       = highlights ? "highlights" : "unreads"
-        const local_prop = highlights ? "highlights" : "local_unreads"
+        const prop      = highlights ? "highlights": "unreads"
+        const localProp = highlights ? "highlights":  "local_unreads"
 
         // When highlights=true, we don't actually find the latest highlight,
         // but instead, the latest unread among all the highlighted rooms.
 
         let max = null
-        let maxevent = null
+        let maxEvent = null
+
         for (let i = 0; i < model.count; i++) {
             const item = model.get(i)
+
             if (
                 item.type === "Room" &&
-                (item[prop] || item[local_prop]) &&
-                (max === null || item.last_event_date < maxevent === oldest)
+                (item[prop] || item[localProp]) &&
+                (max === null || item.last_event_date < maxEvent === oldest)
             ) {
                 max = i
-                maxevent = item.last_event_date
+                maxEvent = item.last_event_date
             }
         }
 

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -137,13 +137,15 @@ HListView {
         // When highlights=true, we don't actually find the latest highlight,
         // but instead, the latest unread among all the highlighted rooms.
 
-        var max = null
-        var maxevent = null
+        let max = null
+        let maxevent = null
         for (let i = 0; i < model.count; i++) {
             const item = model.get(i)
-            if (item.type === "Room"
-            && (item[prop] || item[local_prop])
-            && (max === null || item.last_event_date < maxevent === oldest)) {
+            if (
+                item.type === "Room" &&
+                (item[prop] || item[local_prop]) &&
+                (max === null || item.last_event_date < maxevent === oldest)
+            ) {
                 max = i
                 maxevent = item.last_event_date
             }

--- a/src/gui/MainPane/RoomList.qml
+++ b/src/gui/MainPane/RoomList.qml
@@ -129,6 +129,32 @@ HListView {
         }
     }
 
+    // Find latest highlight or unread. If oldest=true, find oldest instead.
+    function latestUnreadRoom(oldest=false, highlights=false) {
+        const prop       = highlights ? "highlights" : "unreads"
+        const local_prop = highlights ? "highlights" : "local_unreads"
+
+        // When highlights=true, we don't actually find the latest highlight,
+        // but instead, the latest unread among all the highlighted rooms.
+
+        var max = null
+        var maxevent = null
+        for (let i = 0; i < model.count; i++) {
+            const item = model.get(i)
+            if (item.type === "Room"
+            && (item[prop] || item[local_prop])
+            && (max === null || item.last_event_date < maxevent === oldest)) {
+                max = i
+                maxevent = item.last_event_date
+            }
+        }
+
+        if (max === null) return false // No unreads found
+
+        currentIndex = max
+        return true
+    }
+
     function startCorrectItemSearch() {
         correctTimer.start()
     }
@@ -283,6 +309,26 @@ HListView {
     HShortcut {
         sequences: window.settings.Keys.Rooms.next_highlight
         onActivated: cycleUnreadRooms(true, true) && showItemLimiter.restart()
+    }
+
+    HShortcut {
+        sequences: window.settings.Keys.Rooms.latest_unread
+        onActivated: latestUnreadRoom(false) && showItemLimiter.restart()
+    }
+
+    HShortcut {
+        sequences: window.settings.Keys.Rooms.oldest_unread
+        onActivated: latestUnreadRoom(true) && showItemLimiter.restart()
+    }
+
+    HShortcut {
+        sequences: window.settings.Keys.Rooms.latest_highlight
+        onActivated: latestUnreadRoom(false, true) && showItemLimiter.restart()
+    }
+
+    HShortcut {
+        sequences: window.settings.Keys.Rooms.oldest_highlight
+        onActivated: latestUnreadRoom(true, true) && showItemLimiter.restart()
     }
 
     Instantiator {


### PR DESCRIPTION
latest/oldest unread/highlight. Idea is from #186
Default bindings match the bindings for previous/next unread/highlight.

Allows the user to read messages in the order of receiving them.
Or the opposite order, to stay on top of things.

`oldest_highlight` and `latest_highlight` are there for completeness, but I don't think they're actually useful bindings. We can remove them if you think `Ctrl+M` should be spared for something more "important".