### PR TITLE
Made some animations unaffected by theme

### DIFF
--- a/src/gui/Base/HBusyIndicator.qml
+++ b/src/gui/Base/HBusyIndicator.qml
@@ -14,6 +14,6 @@ HCircleProgressBar {
         from: 0
         to: 360
         loops: Animation.Infinite
-        duration: theme ? (theme.animationDuration * 6) : 600
+        duration: 600
     }
 }

--- a/src/gui/Base/HProgressBar.qml
+++ b/src/gui/Base/HProgressBar.qml
@@ -31,7 +31,7 @@ ProgressBar {
 
             HNumberAnimation on x {
                 running: bar.visible && bar.indeterminate
-                duration: theme.animationDuration * 8
+                duration: 800
                 from: 0
                 to: bar.width - indicator.width
 

--- a/src/gui/Pages/AddAccount/ServerBrowser.qml
+++ b/src/gui/Pages/AddAccount/ServerBrowser.qml
@@ -255,7 +255,7 @@ HBox {
     }
 
     Timer {
-        interval: theme.animationDuration * 2
+        interval: 200
         running: true
         repeat: true
         onTriggered:

--- a/src/gui/Popups/ImageViewerPopup/ViewerButtons.qml
+++ b/src/gui/Popups/ImageViewerPopup/ViewerButtons.qml
@@ -72,7 +72,7 @@ HFlow {
         toolTip.text: qsTr("Rotate left")
         autoRepeat: true
         autoRepeatDelay: 20
-        autoRepeatInterval: theme.animationDuration * 3
+        autoRepeatInterval: 300
         onPressed: viewer.animatedRotationTarget -= 45
 
         HPopupShortcut {
@@ -88,7 +88,7 @@ HFlow {
         toolTip.text: qsTr("Rotate right")
         autoRepeat: true
         autoRepeatDelay: 20
-        autoRepeatInterval: theme.animationDuration * 3
+        autoRepeatInterval: 300
         onPressed: viewer.animatedRotationTarget += 45
 
         HPopupShortcut {


### PR DESCRIPTION
People modify animationDuration because they want a snappy client, not [this](https://f.mazie.rocks/mirage_spin.webm).

These things that do not contribute to snappiness and should remain constant speed:
- Busy indicator
- Progress bar animation
- Ping indicator in AddAccount ServerBrowser
- Image rotation button cooldown