### PR TITLE
Flatpak: Don't request host filesystem access

### DIFF
--- a/packaging/flatpak/mirage.flatpak.base.yaml
+++ b/packaging/flatpak/mirage.flatpak.base.yaml
@@ -11,7 +11,6 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
-  - --filesystem=host
   - --talk-name=org.freedesktop.Notifications
 
 rename-icon: mirage

--- a/packaging/flatpak/mirage.flatpak.yaml
+++ b/packaging/flatpak/mirage.flatpak.yaml
@@ -10,7 +10,6 @@ finish-args:
 - --socket=wayland
 - --socket=pulseaudio
 - --device=dri
-- --filesystem=host
 - --talk-name=org.freedesktop.Notifications
 rename-icon: mirage
 rename-desktop-file: mirage.desktop


### PR DESCRIPTION
Mirage is able to use portals for picking files to send, so requesting access to the entire host filesystem is not necessary.