### PR TITLE
Make error popup opaque

### DIFF
--- a/src/gui/Popups/UnexpectedErrorPopup.qml
+++ b/src/gui/Popups/UnexpectedErrorPopup.qml
@@ -13,6 +13,11 @@ HColumnPopup {
 
     property var errors: []  // [{type, message, traceback}]
 
+    background: Rectangle {
+        color: theme.controls.popup.opaqueBackground
+            ? theme.controls.popup.opaqueBackground
+            : theme.controls.popup.background // fallback
+    }
 
     contentWidthLimit: Math.min(window.width / 1.5, 864 * theme.uiScale)
 

--- a/src/themes/Glass.qpl
+++ b/src/themes/Glass.qpl
@@ -116,6 +116,12 @@ controls:
     popup:
         int defaultWidth:    minimumSupportedWidth * 1.75
         color background:    colors.mediumBackground
+        color opaqueBackground: hsluv(
+            colors.hue,
+            colors.bgSaturation,
+            colors.intensity * 7,
+            1
+        )
         color windowOverlay: hsluv(0, 0, 0, 0.7)
 
     header:

--- a/src/themes/Midnight.qpl
+++ b/src/themes/Midnight.qpl
@@ -119,6 +119,12 @@ controls:
     popup:
         int defaultWidth:    minimumSupportedWidth * 1.75
         color background:    colors.mediumBackground
+        color opaqueBackground: hsluv(
+            colors.hue,
+            colors.bgSaturation,
+            colors.intensity * 7,
+            1
+        )
         color windowOverlay: hsluv(0, 0, 0, 0.7)
 
     header:


### PR DESCRIPTION
Sending screenshots of error popups is an easy way to leak information.
But if the popup is transparent, that makes it so much easier.
For the sake of privacy, error popups should be opaque.

BEFORE:
![transparent error popup](https://files.mazie.rocks/Screenshot_2021-08-29_18-57-57.png)

AFTER:
![opaque error popup](https://files.mazie.rocks/Screenshot_2021-08-29_18-57-18.png)

Note: this adds to default themes. It is compatible with old themes, but in that case, errors remain transparent.