### PR TITLE
Disable seen indicator link

### DIFF
--- a/src/gui/Base/HSelectableLabel.qml
+++ b/src/gui/Base/HSelectableLabel.qml
@@ -35,7 +35,8 @@ TextEdit {
     focus: false
     selectByMouse: true
 
-    onLinkActivated: if (enableLinkActivation) Qt.openUrlExternally(link)
+    onLinkActivated: if (enableLinkActivation && link !== '#state-text')
+        Qt.openUrlExternally(link)
 
     MouseArea {
         anchors.fill: label


### PR DESCRIPTION
The seen indicator is a link to #state-text.
This link should not be clickable.
Fixes #247