### PR TITLE
GlobalTapHandlers: limit acceptedPointerTypes to mouse

### DIFF
--- a/src/gui/GlobalTapHandlers.qml
+++ b/src/gui/GlobalTapHandlers.qml
@@ -16,11 +16,13 @@ Item {
     implicitHeight: parent ? parent.height : 0
 
     TapHandler {
+        acceptedPointerTypes: PointerDevice.GenericPointer
         acceptedButtons: Qt.BackButton
         onTapped: root.pageLoader.moveThroughHistory(1)
     }
 
     TapHandler {
+        acceptedPointerTypes: PointerDevice.GenericPointer
         acceptedButtons: Qt.ForwardButton
         onTapped: root.pageLoader.moveThroughHistory(-1)
     }


### PR DESCRIPTION
By default, TapHandler is used for all input types. GlobalTapHandlers
was blocking finger touch events from reaching the underlying elements,
breaking the app for mobile devices with a touch screen. See issue #236