### PR TITLE
replace deprecated collections.abc.Mapping access

### DIFF
--- a/src/backend/utils.py
+++ b/src/backend/utils.py
@@ -70,7 +70,7 @@ def dict_update_recursive(dict1: dict, dict2: dict) -> None:
 
     for k in dict2:
         if (k in dict1 and isinstance(dict1[k], dict) and
-                isinstance(dict2[k], collections.Mapping)):
+                isinstance(dict2[k], collections.abc.Mapping)):
             dict_update_recursive(dict1[k], dict2[k])
         else:
             dict1[k] = dict2[k]


### PR DESCRIPTION
python 3.9 introduced deprecation warnings for accessing for example
collections.Mapping. see
https://docs.python.org/3.9/whatsnew/3.9.html#you-should-check-for-deprecationwarning-in-your-code

it seems like python 3.10.5 provided via
https://images.postmarketos.org/bpo/v22.06/pine64-pinephonepro/sxmo-de-sway/20220727-0517/
no longer exposes Mapping via the collections import:

X 14:42:23 | python:
Traceback (most recent call last):
  File "qrc:/src/backend/user_files.py", line 59, in __post_init__
    self.data, self._need_write = self.deserialized(text)
  File "qrc:/src/backend/user_files.py", line 488, in deserialized
    dict_data, save = super().deserialized(data)
  File "qrc:/src/backend/user_files.py", line 270, in deserialized
    dict_update_recursive(all_data, loaded)
  File "qrc:/src/backend/utils.py", line 73, in dict_update_recursive
    isinstance(dict2[k], collections.Mapping)):
AttributeError: module 'collections' has no attribute 'Mapping'

this patch imports Mapping from the collections module in a not
deprecated way which makes mirage run on postmarketos v22.06.