### PR TITLE
Update mirage.appdata.xml: fix typo in id

### DIFF
--- a/packaging/mirage.appdata.xml
+++ b/packaging/mirage.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>io.github.mirakuna.mirage</id>
+  <id>io.github.mirukana.mirage</id>
   <name>Mirage</name>
   <summary>Customizable and keyboard-operable Matrix client</summary>
   <description>


### PR DESCRIPTION
The App ID seems to have a typo in it. Since my project linuxphoneapps.org relies on this upstream information, it would be great to get this fixed even if you intend to no longer maintain this app/project.

Thank you - I greatly enjoyed the app!